### PR TITLE
Downloaded themes have wrong file extension capitalization

### DIFF
--- a/app/assets/js/controllers/editor_controller.coffee
+++ b/app/assets/js/controllers/editor_controller.coffee
@@ -189,7 +189,7 @@ Angie.controller "editorController", ['$scope', '$http', '$location', 'ThemeLoad
     plist = json2plist($scope.jsonTheme)
     #console.log plist
     blob = new Blob([plist], {type: "text/plain"})
-    saveAs blob, "#{$scope.jsonTheme.name}.tmtheme"
+    saveAs blob, "#{$scope.jsonTheme.name}.tmTheme"
 
   $scope.save_theme = ->
     $scope.update_general_colors()


### PR DESCRIPTION
Downloaded themes had a ".tmtheme" file extension. It should be ".tmTheme".

Fixes this issue: https://github.com/aziz/tmTheme-Editor/issues/11
