### PR TITLE
Scope bar and interaction from preview 

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -39,6 +39,7 @@ app.configure 'production', ->
 app.get '/', routes.index
 app.get '/get_uri', routes.get_uri
 app.get '/stats', routes.stats
+app.get '/partials/:partialName', routes.partials
 
 http.createServer(app).listen settings.port, ->
   console.log "Express server listening on port #{settings.port} in '#{app.get('env')}' environment"

--- a/app/assets/css/app/gallery.less
+++ b/app/assets/css/app/gallery.less
@@ -186,7 +186,7 @@
 
 .tabbar, .sidebar, .titlebar, .actionbar, .preview, .dl-save, .sep,
 #new-popover, #edit-popover, #gallery .titlebar,
-#gallery ul, #gallery .searchbar, .theme-title {
+#gallery ul, #gallery .searchbar, .theme-title, .scope-bar {
   -webkit-transition: -webkit-transform .4s ease;
           transition: transform .4s ease;
   -webkit-backface-visibility: hidden;

--- a/app/assets/css/app/preview.less
+++ b/app/assets/css/app/preview.less
@@ -1,4 +1,20 @@
-s {text-decoration: none;}
+s {
+  text-decoration: none;
+  padding: 2px;
+  margin: -2px;
+  border-radius: 2px;
+  cursor: default;
+
+  &:hover {
+    box-shadow: 0 0 0 2px fadeout(#1eae37, 75);
+    .user-select(none);
+
+    s:hover {
+      background: fadeout(#1eae37, 92);
+    }
+  }
+}
+
 .is_bold { font-weight: bold !important; }
 .is_italic { font-style: italic; }
 .is_underline { text-decoration: underline; }
@@ -7,7 +23,7 @@ pre {background-color: transparent;}
 .preview {
   position: absolute;
   top: @header_height+ 1;
-  bottom: 0;
+  bottom: 33px;
   left: 401px;
   right: 0;
   overflow: scroll;
@@ -41,5 +57,42 @@ pre {background-color: transparent;}
       .user-select(none);
       // position: fixed;
     }
+  }
+}
+
+.scope-bar {
+  #gradient > .vertical(#e8e8ea, #dcdddf);
+  border-top: 1px solid #969696;
+  .box-shadow(inset 0 1px 0 #f5f5f5);
+  position: fixed;
+  bottom: 0px;
+  left: @sidebar_width + 1;
+  right: 0;
+  height: 32px;
+  z-index: 99;
+  color: #666;
+  text-shadow: 0 1px 0 white;
+  cursor: default;
+
+  .f-scope {
+    line-height: 32px;
+    padding: 0 10px;
+  }
+
+  .f-scope + .f-scope {
+    padding-left: 0;
+
+    &:not(:last-child)::before {
+      content: ":";
+      margin-right: 14px;
+      color: #999;
+    }
+  }
+
+  .type-language {
+    color: #996d4b;
+  }
+  .type-entity-text {
+    color: #999;
   }
 }

--- a/app/assets/css/app/sidebar.less
+++ b/app/assets/css/app/sidebar.less
@@ -264,6 +264,7 @@
   }
 
   tr {
+    .transition(160ms);
     border-top: 1px solid transparent;
     border-bottom: 1px solid transparent;
   }
@@ -497,6 +498,14 @@ a.reset {
 
 .ui-sortable-placeholder {
   height: 23px;
+}
+
+.list .hovered {
+  background: fadeout(#00aa25, 85);
+
+  td:last-child {
+    box-shadow: inset -4px 0 0 #00aa25;
+  }
 }
 
 .current_theme_light .selected {

--- a/app/assets/js/controllers/editor_controller.coffee
+++ b/app/assets/js/controllers/editor_controller.coffee
@@ -296,6 +296,7 @@ Angie.controller "editorController", ['$scope', '$http', '$location', 'ThemeLoad
   # ---------------------------------------------------------------------
 
   $scope.is_selected = (rule) -> rule == $scope.selected_rule
+  $scope.is_hovered = (rule) -> rule == $scope.hovered_rule
   $scope.is_gcolor_selected = (rule) -> rule == $scope.general_selected_rule
 
   # $scope.selected_gradient = (rule) ->
@@ -316,21 +317,26 @@ Angie.controller "editorController", ['$scope', '$http', '$location', 'ThemeLoad
     $scope.edit_popover_visible = true
     row = $("#scope-lists .rule-#{rule_index}")
     win_height = $(window).height()
+
     if (win_height - row.offset().top) < 160
       $("#edit-popover").css({
         "top": "auto"
+        "left": ""
         "bottom": win_height - row.offset().top
       }).removeClass("on-bottom").addClass("on-top")
     else if row.offset().top < 160
       $("#edit-popover").css({
+        "left": ""
         "top": row.offset().top + row.outerHeight()
         "bottom": "auto"
       }).removeClass("on-top").addClass("on-bottom")
     else
       $("#edit-popover").css({
         "top": row.offset().top + (row.outerHeight()/2) - 140
+        "left": ""
         "bottom": "auto"
       }).removeClass("on-top").removeClass("on-bottom")
+
     $("#preview, #gallery").one "click", (e) ->
       $scope.edit_popover_visible = false
       $scope.$digest()

--- a/app/assets/js/controllers/preview_controller.coffee
+++ b/app/assets/js/controllers/preview_controller.coffee
@@ -315,7 +315,7 @@ Angie.controller "previewController", ['$scope', '$http', '$rootScope'], ($scope
       #console.log scopes
       for scope, i in scopes
         if scope.type == "b"
-          tag = "<s class='#{scope.name?.split(".").join(" ")}'>"
+          tag = "<s class='#{scope.name?.split(".").join(" ")}' data-entity-scope='#{scope.name}'>"
         else
           tag = "</s>"
         #console.log "TAG:", tag
@@ -327,4 +327,3 @@ Angie.controller "previewController", ['$scope', '$http', '$rootScope'], ($scope
           break if j > scopes.length
       #console.log line
       $scope.parsed_code.push("<span class='l l-#{line_number} #{$scope.json_lang.scopeName.split(".").join(" ")}'>#{line}</span>")
-

--- a/app/assets/js/directives/show-scope.coffee
+++ b/app/assets/js/directives/show-scope.coffee
@@ -1,0 +1,70 @@
+Angie.directive "scopeBar", [], ->
+  replace: true
+  templateUrl: 'partials/scope_bar'
+
+  link: (scope, element, attr) ->
+    preview = element.prev()
+    preview.bind "mouseover", (event) ->
+      active = {}
+      active.scope = event.target.dataset.entityScope
+
+      if active.scope
+        active_scope_rule = getScopeSettings(active.scope)
+        active.name = active_scope_rule.name if active_scope_rule
+
+      scope.$apply ->
+        # Highlight in sidebar
+        scope.$parent.hovered_rule = active_scope_rule
+
+    preview.bind "mouseout", (event) ->
+      # Unhighlight in sidebar
+      scope.$parent.hovered_rule = null
+
+    preview.bind "dblclick", (event) ->
+      active = {}
+      active.scope = event.target.dataset.entityScope
+
+      if active.scope
+        active_scope_rule = getScopeSettings(active.scope)
+        showPopover active_scope_rule, event
+
+
+
+    showPopover = (rule, event) ->
+      scope.$apply ->
+        scope.$parent.new_popover_visible = false
+        scope.$parent.popover_rule = rule
+        scope.$parent.edit_popover_visible = true
+
+      popover = $("#edit-popover")
+
+      if popover.is('.slide')
+        left_offset = $("#gallery").width()
+      else
+        left_offset = 0
+
+      offset =
+        left: (popover.width() / 2) + 10 + left_offset
+        top: 24
+
+      popover.css({
+        "left": event.pageX - offset.left
+        "top": event.pageY + offset.top
+      }).addClass("on-bottom")
+
+
+    getScopeSettings = (active_scope) ->
+      return unless scope.$parent.jsonTheme.settings
+
+      return scope.$parent.jsonTheme.settings.find (item) ->
+        return unless item.scope
+
+        item_scopes = item.scope.split(', ')
+
+        match = item_scopes.filter (item_scope) ->
+          item_scopes_arr = item_scope.split('.')
+          active_scope_arr = active_scope.split('.')
+
+          return (item_scopes_arr.subtract active_scope_arr).length < 1
+
+        return item if match.length

--- a/app/routes/index.coffee
+++ b/app/routes/index.coffee
@@ -15,6 +15,10 @@ routes.stats = (req, res) ->
   view = {}
   res.render 'stats', view
 
+routes.partials = (req, res) ->
+  view = {}
+  res.render "_#{req.params.partialName}", view
+
 module.exports = routes
 
 

--- a/app/templates/_scope_bar.ejs
+++ b/app/templates/_scope_bar.ejs
@@ -1,0 +1,5 @@
+<div ng-cloak ng-class="gallery" class="scope-bar">
+  <strong class="f-scope type-language">{{ json_lang.scopeName }}</strong>
+  <span ng-show="hovered_rule.scope" class="f-scope type-entity">{{ hovered_rule.scope }}</span>
+  <span ng-show="hovered_rule.name" class="f-scope type-entity-text">({{ hovered_rule.name }})</span>
+</div>

--- a/app/templates/_table_scopes.ejs
+++ b/app/templates/_table_scopes.ejs
@@ -15,7 +15,7 @@
         ng-hide="rule.settings.invisibles"
         ng-click="mark_as_selected(rule)"
         ng-dblclick="toggle_edit_popover(rule, $index)"
-        ng-class="{ 'selected': is_selected(rule) }"
+        ng-class="{ 'selected': is_selected(rule), 'hovered': is_hovered(rule) }"
         class="rule-{{$index}}">
       <td class="name-box"
           ng-style="{ 'color': get_color(rule.settings.foreground), 'background-color': get_color(rule.settings.background) }"

--- a/app/templates/index.ejs
+++ b/app/templates/index.ejs
@@ -28,6 +28,8 @@
          ng-style="{ 'color': get_color(fg()) }"></pre>
   </div>
 
+  <div scope-bar></div>
+
 </div>
 <div id="loading"></div>
 <% include _edit_dialog %>


### PR DESCRIPTION
This adds a scope bar at the bottom of the preview.

The bar shows current scope of the current language and also currently hovered element. User can also interact with  the element straight from the preview by double-clicking it. This will bring up the scope colour popover for the corresponding scope.

![scope-bar](https://f.cloud.github.com/assets/203886/665636/13e25580-d7a5-11e2-9b50-493b9601cf3b.png)
