### PR TITLE
Script to init node_modules and start server

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ As a side project I started to write a tmLanguage parser in javascript to be abl
 written in [coffeescript](http://coffeescript.org/) using [angular.js](angularjs.org)
 
 
+## Install
+
+```bash
+git clone git@github.com:aziz/tmTheme-Editor.git
+cd tmTheme-editor
+./start.sh
+```
+
+The `start` script will:
+
+- Run `npm install` if *node_modules* is missing;
+- Bring up the express server at [http://localhost:9999](http://localhost:9999)
+
 ## Copyright
 **TMThemeEditor**  
 &copy; Copyright 2012-2013 Allen Bargi

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [ ! -d "node_modules" ]; then
+	npm install
+fi
+
+if hash coffee 2>/dev/null; then
+	coffee app.coffee
+else
+	./node_modules/coffee-script/bin/coffee app.coffee
+fi


### PR DESCRIPTION
I don't use `coffee` much, so I don't have the global coffee npm installed.

Typing `./node_modules/coffee-script/bin/coffee app.coffee` is tiresome, so I wrote a little script in the project root to start the app with either a global (if the user has it) or project-local `coffee`.

I threw in a check for _node_modules_ and run `npm install` if it's missing. Running `start.sh` immediately after cloning sets up everything.

I added a few lines in the README to that effect.

Side-note: I think I have to deploy this to my company LAN tomorrow because **everyone** in my office is going to want to use it :thumbsup: It's super awesome.
