### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "morgan": "1.6.0",
     "uglify-js": "2.4.23",
     "bower": "1.7.7",
-    "request": "2.58.0",
+    "request": "2.74.0",
     "coffee-script": "1.9.3",
     "connect-assets": "4.7.1",
     "csswring": "3.0.5",


### PR DESCRIPTION
tmTheme-Editor currently has a 3 vulnerable dependencies, introducing 5 different types of known vulnerabilities.

This PR fixes vulnerable dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency and [ReDos vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.

You can see [Snyk test report](https://snyk.io/test/github/aziz/tmTheme-Editor) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade  `compression`, `errorhandler`,` uglify-js` and `connect-assets` dependencies as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)