### PR TITLE
add Tomorrow Night Burns theme

### DIFF
--- a/app/front/public/gallery.json
+++ b/app/front/public/gallery.json
@@ -707,6 +707,7 @@
 {"name":"Tomorrow-Night","url":"https://raw.githubusercontent.com/theymaybecoders/sublime-tomorrow-theme/master/Tomorrow-Night.tmTheme","light":false},
 {"name":"Tomorrow-Night-Blue","url":"https://raw.githubusercontent.com/theymaybecoders/sublime-tomorrow-theme/master/Tomorrow-Night-Blue.tmTheme","light":false},
 {"name":"Tomorrow-Night-Bright","url":"https://raw.githubusercontent.com/theymaybecoders/sublime-tomorrow-theme/master/Tomorrow-Night-Bright.tmTheme","light":false},
+{"name":"Tomorrow-Night-Burns","url":"https://raw.githubusercontent.com/ashwinv11/sublime-boxy/dev/schemes/Boxy%20Tomorrow%20Burns.tmTheme","light":false},
 {"name":"Tomorrow-Night-Eighties","url":"https://raw.githubusercontent.com/theymaybecoders/sublime-tomorrow-theme/master/Tomorrow-Night-Eighties.tmTheme","light":false},
 {"name":"Tonic","url":"https://raw.githubusercontent.com/daylerees/colour-schemes/master/sublime/tonic.tmTheme","light":false},
 {"name":"Toulousse Lautrec","url":"https://raw.githubusercontent.com/imagentleman/ublime/master/Toulousse-Lautrec.tmTheme","light":true},


### PR DESCRIPTION
I wrote this theme based on the [Boxy Tomorrow](https://github.com/ihodev/sublime-boxy) theme. I wanted to create a unified look with with the red and grayscale color scheme. I went with 'Tomorrow Burns' because it reminds me of a 'hellish wasteland'.

<img width="1434" alt="boxy_tomorrow_burns_2" src="https://user-images.githubusercontent.com/5572129/29706659-74216786-8937-11e7-9cd2-e65ca7accd79.png">
<img width="1435" alt="boxy_tomorrow_burns" src="https://user-images.githubusercontent.com/5572129/29706660-7421599e-8937-11e7-9d00-d059fd38f895.png">
